### PR TITLE
Add a column to display estimated expiration date

### DIFF
--- a/src/tipjar_assets/src/index.html
+++ b/src/tipjar_assets/src/index.html
@@ -44,6 +44,7 @@
       th {
         font-weight: normal;
         min-width: 5rem;
+        vertical-align: top;
       }
       .left {
         text-align: left;
@@ -354,11 +355,12 @@
               <th class="fixed-th">Canister</th>
               <th class="right">Allocated</th>
               <th class="right">Donated</th>
+              <th class="right">Est. Expiration Date</th>
             </tr>
           </thead>
           <tbody id="canisters">
             <tr>
-              <td colspan="3" id="login_area">
+              <td colspan="4" id="login_area">
                 <div id="add_canister_form" hidden>
                   <div class="center">
                     <div class="table-inner">

--- a/src/tipjar_assets/src/index.js
+++ b/src/tipjar_assets/src/index.js
@@ -164,6 +164,29 @@ function toDays(period) {
   return Number(period / 1000000000n / 3600n / 24n);
 }
 
+function calculateEstimatedDays(allocation) {
+  let canister = allocation.canister;
+  if (canister.usage.length <= 3) {
+    return "N/A";
+  }
+  
+  var usage = 0n;
+  var period = 0n;
+  for (var i = 0; i < canister.usage.length; i++) {
+    usage += canister.usage[i].cycle;
+    period += canister.usage[i].period;
+  }
+  period = period / 3600000000000n;
+  if (period > 0) {
+    let hourly = usage / period;
+    if (hourly > 0) {
+      let days = canister.total_allocation / hourly / 24n;
+      return Number(days);
+    }
+  }
+  return "N/A";
+}
+
 function canister_summary(allocation) {
   let canister = allocation.canister;
   console.log(canister);
@@ -212,12 +235,28 @@ function canister_summary(allocation) {
 
 function canister_row(allocation) {
   let id = allocation.canister.id.toString();
+  let estimatedDays = calculateEstimatedDays(allocation);
+  let expirationText;
+  
+  if (estimatedDays === "N/A") {
+    expirationText = "N/A";
+  } else {
+    let expirationDate = new Date();
+    expirationDate.setDate(expirationDate.getDate() + estimatedDays);
+    expirationText = expirationDate.toLocaleDateString('en-US', { 
+      month: 'short', 
+      day: 'numeric', 
+      year: 'numeric' 
+    });
+  }
+  
   return [
     `<td><a id='anchor_${id}'>${formatAlias(
       allocation,
     )}<span class="max"><i class="far fa-edit"></i></span></a></td>`,
     `<td class='right'>${formatCycle(allocation.allocated)}T</td>`,
     `<td class='right'>${formatCycle(allocation.donated)}T</td>`,
+    `<td class='right'>${expirationText}</td>`,
   ].join("");
 }
 
@@ -304,7 +343,7 @@ async function save_canister(tr, id, allocation) {
 function show_canister(tr, allocation, autofocus = false) {
   let id = allocation.canister.id;
   tr.innerHTML = [
-    `<td colspan='3'><a>${formatAlias(allocation)}</a><br>`,
+    `<td colspan='4'><a>${formatAlias(allocation)}</a><br>`,
     "<div class='center'><div class='table-inner'>",
     `<label class='input-label' for='alias_${id}'><b>Alias</b></label><div class="input-box-wrapper"><div id="alias_${id}_spinner" hidden><i class="fas fa-spinner fa-spin"></i></div><input autocomplete="off" id='alias_${id}' value='${allocation.alias}' /></div><br>`,
     `<label class='input-label' for='allocated_${id}'><b>Allocated</b></label><div class="input-box-wrapper"><div id="allocated_${id}_spinner" hidden><i class="fas fa-spinner fa-spin"></i></div><input autocomplete="off" id='allocated_${id}' value='${formatCycle(


### PR DESCRIPTION
This PR tries to display the estimated expiration date directly in the user's dashboard table as the fourth column to the right. 

- The original code displays only 3 columns: Canister, Allocated, and Donated. 
- The user has to click on the specific canister to open up a collapsed menu to see more details.
- Among those details, the estimated days remaining (before cycles run out) is probably the most vital statistic for the user.
- This PR would display this statistic (but in the transformed format of July 7, 2026) directly in the dashboard table, without the user having to click on the canister ID.
- The effect looks like this on a local replica:
![Screenshot 2025-07-07 at 14 41 14](https://github.com/user-attachments/assets/6cc89d05-fb9d-4b70-943a-ad1e64a3c68b)
- The original `.gitignore` leaves room for some environmental or artifact files. I did not stage those for my commit. This is supposed to be a simple UI change. The only affected files should be the index.html and index.js, I think. 
![Screenshot 2025-07-07 at 14 50 07](https://github.com/user-attachments/assets/f89dea6d-1d1f-4af2-b58b-2cc2a2393376)
